### PR TITLE
add ssl support

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 var (
 	listenAddress  = flag.String("listen", ":80", "Server Listen Address")
 	sshAddress     = flag.String("ssh", "127.0.0.1:22", "SSH Server Address")
+	sslAddress     = flag.String("ssl", ":443", "SSL Server address(usually https)")
 	defaultAddress = flag.String("default", "127.0.0.1:8080", "Default Server Address")
 )
 
@@ -36,6 +37,7 @@ func main() {
 	mux := NewMux()
 
 	mux.Handle(SSH(*sshAddress))
+	mux.Handle(SSL(*sslAddress))
 	mux.Handle(TCP(*defaultAddress))
 
 	log.Printf("[INFO] listen: %s\n", *listenAddress)

--- a/ssh.go
+++ b/ssh.go
@@ -17,6 +17,5 @@ func (s SSH) Identify(header []byte) bool {
 	if bytes.Compare(header, []byte("SSH")) == 0 {
 		return true
 	}
-
 	return false
 }

--- a/ssl.go
+++ b/ssl.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"bytes"
+)
+
+type SSL string
+
+// address to proxy to
+func (t SSL) Address() string {
+	return string(t)
+}
+
+// identify header as one of TCP
+func (t SSL) Identify(header []byte) bool {
+	// this is a dummy protocol handler used for the default
+	if bytes.Equal(header[:2], []byte{0x16, 0x03}) && header[2] >= 0x00 && header[2] <= 0x03 {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
```
  // TLS starts as
  // 0: 0x16 - handshake protocol magic
  // 1: 0x03 - SSL version major
  // 2: 0x00 to 0x03 - SSL version minor (SSLv3 or TLS1.0 through TLS1.3)
  // 3-4: length (2 bytes)
  // 5: 0x01 - handshake type (ClientHello)
  // 6-8: handshake len (3 bytes), equals value from offset 3-4 minus 4
```
